### PR TITLE
Skip enrolment if course is empty for user

### DIFF
--- a/classes/user.php
+++ b/classes/user.php
@@ -990,6 +990,9 @@ class tool_uploadusercli_user {
                     }
                 }
             } else if (preg_match('/^course\d+$/', $field)) {
+                if (empty($value))
+                    continue;
+
                 // Course number.
                 $i = substr($field, 6);
                 $shortname = $value;


### PR DESCRIPTION
This commit fixes the following issue: uploading a csv that has empty
course/role for an user generates an error.
For the following file:
username;firstname;lastname;email;idnumber;auth;cohort1;course1;role1
<username>;<firstname>;<lastname>;<email>;<idnumber>;<auth>;<cohort>;;
    
The following command fails:
php uploadusercli/cli/uploadusercli.php
    --mode=createorupdate --updatemode=dataonly --file=file.csv
    --delimiter=semicolon --allowdeletes=false --allowrenames=false
    --standardise=false --updatepassword=false --allowsuspends=false
    --noemailduplicates=false --forcepasswordchange=all
line        result  username        firstname       lastname        email id
PHP Warning:  Creating default object from empty value in
<path_to_moodle>/admin/tool/uploadusercli/classes/user.php
on line 999
PHP Notice:  Undefined property: stdClass::$id in
<path_to_moodle>/admin/tool/uploadusercli/classes/user.php
on line 1005
Default exception handler: Can't find data record in database table
course. Debug: SELECT id,category FROM {course} WHERE id IS NULL
[array (
    )]
Error code: invalidrecord
* line 1599 of /lib/dml/moodle_database.php:
* dml_missing_record_exception thrown
* line 1575 of /lib/dml/moodle_database.php: call to
* moodle_database->get_record_select()
* line 6928 of /lib/accesslib.php: call to moodle_database->get_record()
* line 1006 of /admin/tool/uploadusercli/classes/user.php: call to
* context_course::instance()
* line 632 of /admin/tool/uploadusercli/classes/user.php: call to
* tool_uploadusercli_user->add_to_egr()
* line 240 of /admin/tool/uploadusercli/classes/processor.php: call to
* tool_uploadusercli_user->proceed()
* line 254 of /admin/tool/uploadusercli/cli/uploadusercli.php: call to
* tool_uploadusercli_processor->execute()
    
!!! Can't find data record in database table course. !!!
!! SELECT id,category FROM {course} WHERE id IS NULL
[array (
    )]
Error code: invalidrecord !!
!! Stack trace: * line 1599 of /lib/dml/moodle_database.php:
dml_missing_record_exception thrown
* line 1575 of /lib/dml/moodle_database.php: call to
* moodle_database-&gt;get_record_select()
* line 6928 of /lib/accesslib.php: call to
* moodle_database-&gt;get_record()
* line 1006 of /admin/tool/uploadusercli/classes/user.php: call to
* context_course::instance()
* line 632 of /admin/tool/uploadusercli/classes/user.php: call to
* tool_uploadusercli_user-&gt;add_to_egr()
* line 240 of /admin/tool/uploadusercli/classes/processor.php: call to
* tool_uploadusercli_user-&gt;proceed()
* line 254 of /admin/tool/uploadusercli/cli/uploadusercli.php: call to
* tool_uploadusercli_processor-&gt;execute()

Signed-off-by: Elena Mihailescu <elenamihailescu22@gmail.com>
